### PR TITLE
Treat as same site

### DIFF
--- a/ext/webextension/src/browser_action/main_popup.js
+++ b/ext/webextension/src/browser_action/main_popup.js
@@ -301,7 +301,16 @@ function popup(masterkey) {
 }
 
 window.addEventListener('load', function () {
-    config.get(['username', 'key_id', 'defaulttype', 'pass_to_clipboard', 'pass_store', 'passwdtimeout', 'use_sync', 'defaultname'])
+    config.get([
+        'username',
+        'key_id',
+        'defaulttype',
+        'pass_to_clipboard',
+        'pass_store',
+        'passwdtimeout',
+        'use_sync',
+        'defaultname',
+    ])
     .then(v=>{
         return runtimeSendMessage({action: 'masterkey_get', use_pass_store: !!v.pass_store});
     })

--- a/ext/webextension/src/css/mpwd.css
+++ b/ext/webextension/src/css/mpwd.css
@@ -87,7 +87,10 @@ button:focus, input:focus, mp-combobox:focus-within {
   outline-style: auto;
 }
 
-input, select, mp-combobox {
+input,
+select,
+mp-combobox,
+no-op {
     background: #1b1d23;
     color: #d7dae0;
     height: 2em;
@@ -198,7 +201,8 @@ button#siteconfig_show {
 }
 #siteconfig > input,
 #siteconfig > select,
-#siteconfig > option {
+#siteconfig > option,
+no-op {
     font-size: 1em;
     font-weight: normal;
     width: 6em;
@@ -302,7 +306,8 @@ button#siteconfig_show {
 
 .configitem > input,
 .configitem > select,
-.configitem > option {
+.configitem > option,
+no-op {
     margin-top:1.5em;
     margin-left:-8em;
     font-size: 1em;

--- a/ext/webextension/src/css/mpwd.css
+++ b/ext/webextension/src/css/mpwd.css
@@ -90,6 +90,7 @@ button:focus, input:focus, mp-combobox:focus-within {
 input,
 select,
 mp-combobox,
+textarea,
 no-op {
     background: #1b1d23;
     color: #d7dae0;
@@ -307,6 +308,7 @@ no-op {
 .configitem > input,
 .configitem > select,
 .configitem > option,
+.configitem > textarea,
 no-op {
     margin-top:1.5em;
     margin-left:-8em;
@@ -319,6 +321,25 @@ no-op {
 .configitem > input[type=checkbox] {
     margin-left: -2em;
     margin-top:0.2em;
+}
+
+.configitem > textarea#treat_as_same_site {
+    width: 11.5em;
+    height: 13em;
+    font-size: 0.7em;
+    margin-left: -11.5em;
+    margin-top: 2em;
+    white-space: nowrap;
+}
+
+/* FIXME: I don't understand how the left alignment of inputs works here, 
+          using negative margins and wrapping - so I just manually margin-left
+          by eye to line up - however it would be better to align this p
+          the same way as the input it is annotating */
+.configitem > textarea#treat_as_same_site + p {
+    font-size: 0.6em;
+    margin-left: 6.7em;
+    line-height: normal;
 }
 
 #stored_sites {

--- a/ext/webextension/src/lib/config.js
+++ b/ext/webextension/src/lib/config.js
@@ -53,6 +53,9 @@ class Config {
     get passwdtimeout() { if (typeof this._cache.passwdtimeout === 'undefined')
                         throw new Error("need get(['passwdtimeout'])");
                      else return this._cache.passwdtimeout; }
+    get treat_as_same_site() { if (typeof this._cache.treat_as_same_site === 'undefined')
+                        throw new Error("need get(['treat_as_same_site'])");
+                     else return this._cache.treat_as_same_site; }
     get use_sync() { if (typeof this._cache.use_sync === 'undefined')
                         throw new Error("need get(['use_sync'])");
                      else return this._cache.use_sync; }
@@ -137,7 +140,7 @@ class Config {
             if (lst.includes('username')) result.username = result.username || '';
             if (lst.includes('pass_store')) result.pass_store = !!result.pass_store;
             if (lst.includes('passwdtimeout')) result.passwdtimeout = isNaN(result.passwdtimeout) ? -1 : result.passwdtimeout;
-
+            if (lst.includes('treat_as_same_site')) result.treat_as_same_site = result.treat_as_same_site || [ '.ac.*', '.co.*', '.com.*', '.edu.*', '.geek.*', '.gov.*', '.govt.*', '.net.*', '.org.*', '.school.*' ].join('\n');
             Object.assign(this._cache, result);
 
             return singlekey ? result[lst[0]] : result;

--- a/ext/webextension/src/lib/utils.js
+++ b/ext/webextension/src/lib/utils.js
@@ -46,3 +46,8 @@ export function copy_to_clipboard(mimetype, data) {
     document.execCommand("Copy", false, null);
     document.oncopy=null;
 }
+
+export function regexpEscape(string) {
+    // https://stackoverflow.com/a/6969486
+    return string.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'); // $& means the whole matched string
+}

--- a/ext/webextension/src/options/globaloptions.js
+++ b/ext/webextension/src/options/globaloptions.js
@@ -150,14 +150,16 @@ document.querySelector('#use_sync').addEventListener('change', async function() 
 });
 
 window.addEventListener('load', function() {
-    config.get(['defaulttype',
-         'defaultname',
-         'passwdtimeout',
-         'pass_to_clipboard',
-         'auto_submit_pass',
-         'auto_submit_username',
-         'pass_store',
-         'use_sync'])
+    config.get([
+        'defaulttype',
+        'defaultname',
+        'passwdtimeout',
+        'pass_to_clipboard',
+        'auto_submit_pass',
+        'auto_submit_username',
+        'pass_store',
+        'use_sync',
+    ])
     .then(data => {
         data = Object.assign({defaulttype: 'l', passwdtimeout: 0, pass_to_clipboard: true,
                  defaultname: '',

--- a/ext/webextension/src/options/globaloptions.js
+++ b/ext/webextension/src/options/globaloptions.js
@@ -58,6 +58,9 @@ document.querySelector('#auto_submit_username').addEventListener('change', funct
 document.querySelector('#pass_store').addEventListener('change', function() {
     config.set({pass_store: this.checked});
 });
+document.querySelector('#treat_as_same_site').addEventListener('change', function() {
+    config.set({treat_as_same_site: this.value});
+});
 document.querySelector('#use_sync').addEventListener('change', async function() {
     let oldstore = (this.checked?chrome.storage.local:chrome.storage.sync);
     let newstore = (!this.checked?chrome.storage.local:chrome.storage.sync);
@@ -158,6 +161,7 @@ window.addEventListener('load', function() {
         'auto_submit_pass',
         'auto_submit_username',
         'pass_store',
+        'treat_as_same_site',
         'use_sync',
     ])
     .then(data => {
@@ -172,6 +176,7 @@ window.addEventListener('load', function() {
         document.querySelector('#auto_submit_pass').checked = data.auto_submit_pass;
         document.querySelector('#auto_submit_username').checked = data.auto_submit_username;
         document.querySelector('#pass_store').checked = data.pass_store;
+        document.querySelector('#treat_as_same_site').value = data.treat_as_same_site;
         document.querySelector('#use_sync').checked = data.use_sync;
     });
 });

--- a/ext/webextension/src/options/index.html
+++ b/ext/webextension/src/options/index.html
@@ -65,6 +65,20 @@
                     <label class="w3-label w3-small w3-text-white" for="defaultname">Default username:</label>
                     <input class="w3-select w3-small w3-border" id="defaultname">
                 </div>
+                <div class="configitem">
+                    <label class="w3-label w3-small w3-text-white" for="treat_as_same_site">Override as same site</label>
+                    <textarea class="w3-label w3-small w3-text-white" id="treat_as_same_site"></textarea>
+                    <p class="w3-label w3-small w3-text-white">
+                        - Enter overrides above, one per line<br />
+                        - lines must start with a . (period)<br />
+                        - lines that cannot be parsed are ignored<br />
+                        - <b>*</b> is wildcard, will match anything except . (period)<br />
+                        - Example:<br />
+                        &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<b>.net.*</b> will treat <i>x.net.nz</i> as a site,<br />
+                        &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;instead of ignoring <i>x</i> and using <i>net.nz</i> as the site
+                    </p>
+                </div>
+
             </div>
             <div class="configsubgroup right">
                 <div class="configitem">

--- a/ext/webextension/src/options/index.html
+++ b/ext/webextension/src/options/index.html
@@ -34,59 +34,59 @@
         <h2 class="accordion_toggle">Global settings</h2>
         <div class="configgroup">
             <div class="configsubgroup left">
-            <div class="configitem">
-                <label class="w3-label w3-small w3-text-white" for="passwdtype">Default password type:</label>
-                 <select class="w3-select w3-small w3-border" id="passwdtype">
-                    <option value="x">Maximum
-                    <option value="l">Long
-                    <option value="m">Medium
-                    <option value="b">Basic
-                    <option value="s">Short
-                    <option value="i">Pin
-                    <option value="n">Name
-                    <option value="p">Phrase
-                    <option value="nx">Name [V]
-                    <option value="px">Phrase [V]
-                </select>
-            </div>
-            <div class="configitem">
-                <label class="w3-label w3-small w3-text-white" for="passwdtimeout">Remember password:</label>
-                <select class="w3-select w3-small w3-border" id="passwdtimeout">
-                    <option value="0">Never
-                    <option value="5">5 minutes
-                    <option value="15">15 minutes
-                    <option value="30">30 minutes
-                    <option value="60">1 hour
-                    <option value="480">8 hours
-                    <option value="-1">Until closed
-                </select>
-            </div>
-            <div class="configitem">
-                <label class="w3-label w3-small w3-text-white" for="defaultname">Default username:</label>
-                <input class="w3-select w3-small w3-border" id="defaultname">
-            </div>
+                <div class="configitem">
+                    <label class="w3-label w3-small w3-text-white" for="passwdtype">Default password type:</label>
+                    <select class="w3-select w3-small w3-border" id="passwdtype">
+                        <option value="x">Maximum
+                        <option value="l">Long
+                        <option value="m">Medium
+                        <option value="b">Basic
+                        <option value="s">Short
+                        <option value="i">Pin
+                        <option value="n">Name
+                        <option value="p">Phrase
+                        <option value="nx">Name [V]
+                        <option value="px">Phrase [V]
+                    </select>
+                </div>
+                <div class="configitem">
+                    <label class="w3-label w3-small w3-text-white" for="passwdtimeout">Remember password:</label>
+                    <select class="w3-select w3-small w3-border" id="passwdtimeout">
+                        <option value="0">Never
+                        <option value="5">5 minutes
+                        <option value="15">15 minutes
+                        <option value="30">30 minutes
+                        <option value="60">1 hour
+                        <option value="480">8 hours
+                        <option value="-1">Until closed
+                    </select>
+                </div>
+                <div class="configitem">
+                    <label class="w3-label w3-small w3-text-white" for="defaultname">Default username:</label>
+                    <input class="w3-select w3-small w3-border" id="defaultname">
+                </div>
             </div>
             <div class="configsubgroup right">
-            <div class="configitem">
-                <label for="pass_to_clipboard">Copy password to clipboard</label>
-                <input id="pass_to_clipboard" type="checkbox"/>
-            </div>
-            <div class="configitem">
-                <label for="auto_submit_pass">Submit after password inject</label>
-                <input id="auto_submit_pass" type="checkbox"/>
-            </div>
-            <div class="configitem">
-                <label for="auto_submit_username">Inject username</label>
-                <input id="auto_submit_username" type="checkbox"/>
-            </div>
-            <div class="configitem">
-                <label for="pass_store">Use OS' password store</label>
-                <input id="pass_store" type="checkbox"/>
-            </div>
-            <div class="configitem">
-                <label for="use_sync">Let browser sync site data</label>
-                <input id="use_sync" type="checkbox"/>
-            </div>
+                <div class="configitem">
+                    <label for="pass_to_clipboard">Copy password to clipboard</label>
+                    <input id="pass_to_clipboard" type="checkbox"/>
+                </div>
+                <div class="configitem">
+                    <label for="auto_submit_pass">Submit after password inject</label>
+                    <input id="auto_submit_pass" type="checkbox"/>
+                </div>
+                <div class="configitem">
+                    <label for="auto_submit_username">Inject username</label>
+                    <input id="auto_submit_username" type="checkbox"/>
+                </div>
+                <div class="configitem">
+                    <label for="pass_store">Use OS' password store</label>
+                    <input id="pass_store" type="checkbox"/>
+                </div>
+                <div class="configitem">
+                    <label for="use_sync">Let browser sync site data</label>
+                    <input id="use_sync" type="checkbox"/>
+                </div>
             </div>
         </div>
     </div>

--- a/ext/webextension/src/options/options.html
+++ b/ext/webextension/src/options/options.html
@@ -8,7 +8,6 @@ body { max-width: 30em; }
 div.item {
     break-inside: avoid;
     width:100%;
-    height:3em;
     display:flex;
     justify-content: space-between;
     align-items: center;
@@ -27,6 +26,7 @@ label {
 input,
 select,
 option,
+textarea,
 no-op {
     display:block;
     border: 0;
@@ -36,6 +36,11 @@ no-op {
 select > option { background: white}
 input[type=checkbox] {
     width:1em;
+}
+#treat_as_same_site {
+    height: 15em;
+    white-space: nowrap;
+    overflow: auto;
 }
 
 </style>
@@ -71,6 +76,11 @@ input[type=checkbox] {
     <div class="item">
         <label for="defaultname">Default username</label>
             <input id="defaultname">
+    </div>
+    <div class="item">
+        <label for="treat_as_same_site">Override as same site</label>
+        <textarea id="treat_as_same_site"></textarea>
+
     </div>
     <div class="item">
         <label for="pass_to_clipboard">Copy password to clipboard</label>

--- a/ext/webextension/src/options/options.html
+++ b/ext/webextension/src/options/options.html
@@ -26,7 +26,8 @@ label {
 
 input,
 select,
-option {
+option,
+no-op {
     display:block;
     border: 0;
     width: 14em;


### PR DESCRIPTION
Add new sync'd option 'treat_as_same_site', which allows configuration of which parts of a domain should be used to identify a site vs it's subdomains or base domains.

Update both options pages to include this, with instructions how to use it. Default to sane values which preserve previous functionality (hardcoded recognition of .co.* domains)
Rewrite domain matching routine to use new configuration option using regexes.

This patch fixes an issue where countries that use second-level domains (.net.nz, .co.nz, .org.nz, .gov.nz) were misidentified with the second level domain part being used as the site name.
It has sane defaults, but allows configuration so that users can customise for the particulars of their country and other websites that use a two-level base domain system.

This should be fully future proof now.

This is an adaption of my feature of the same name from masterpassword-chrome